### PR TITLE
MIME parsing updates

### DIFF
--- a/src/Dflydev/ApacheMimeTypes/AbstractRepository.php
+++ b/src/Dflydev/ApacheMimeTypes/AbstractRepository.php
@@ -83,9 +83,21 @@ abstract class AbstractRepository implements RepositoryInterface
     /**
      * {@inheritdoc}
      */
+    public function findExtension($type)
+    {
+      $extensions = $this->findExtensions($type);
+      if(count($extensions)==0) return null;
+      return $extensions[0];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function findExtensions($type)
     {
         $this->init();
+        
+        $type = explode(';', strtolower($type))[0];
 
         if (isset($this->typeToExtensions[$type])) {
             return $this->typeToExtensions[$type];

--- a/src/Dflydev/ApacheMimeTypes/PhpRepository.php
+++ b/src/Dflydev/ApacheMimeTypes/PhpRepository.php
@@ -16,7 +16,7 @@ namespace Dflydev\ApacheMimeTypes;
  *
  * @author Beau Simensen <beau@dflydev.com>
  */
-class PhpRepository implements RepositoryInterface
+class PhpRepository extends AbstractRepository
 {
     protected $extensionToType = array(
         'ez' => 'application/andrew-inset',
@@ -1769,44 +1769,9 @@ class PhpRepository implements RepositoryInterface
         'video/x-smv' => array('smv'),
         'x-conference/x-cooltalk' => array('ice'),
     );
-
-    /**
-     * {@inheritdoc}
-     */
-    public function dumpExtensionToType()
+    
+    protected function internalInit()
     {
-        return $this->extensionToType;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function dumpTypeToExtensions()
-    {
-        return $this->typeToExtensions;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function findExtensions($type)
-    {
-        if (isset($this->typeToExtensions[$type])) {
-            return $this->typeToExtensions[$type];
-        }
-
-        return array();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function findType($extension)
-    {
-        if (isset($this->extensionToType[$extension])) {
-            return $this->extensionToType[$extension];
-        }
-
-        return null;
+      
     }
 }

--- a/src/Dflydev/ApacheMimeTypes/RepositoryInterface.php
+++ b/src/Dflydev/ApacheMimeTypes/RepositoryInterface.php
@@ -33,6 +33,15 @@ interface RepositoryInterface
     public function dumpTypeToExtensions();
 
     /**
+     * Find first extension for a type
+     *
+     * @param string $type
+     *
+     * @return array
+     */
+    public function findExtension($type);
+
+    /**
      * Find all extensions for a type
      *
      * @param string $type


### PR DESCRIPTION
Some MIME types that include a semicolon (;) do not parse correctly. This fixes that parsing error and adds a findExtension method to look up a correct extension based on MIME type. The phpRepository class is updated as a result.
